### PR TITLE
Rollover extra fields in layer registration to reply

### DIFF
--- a/src/main/scala/com/azavea/modellab/JsonMerge.scala
+++ b/src/main/scala/com/azavea/modellab/JsonMerge.scala
@@ -1,0 +1,39 @@
+package com.azavea.modellab
+
+import spray.json._
+
+import scala.util.Try
+
+object JsonMerge {
+  /** merge two maps, source values preferentially from left map */
+  def mergeMaps(m1: Map[String, JsValue], m2: Map[String, JsValue]): Map[String, JsValue] = {
+    for (key <- m1.keySet ++ m2.keySet) yield {
+      val value: JsValue = m1.get(key) match {
+        case Some(left: JsObject) =>
+          m2.get(key) match {
+            case Some(right) => JsonMerge(left, right)
+            case None => left
+          }
+        case Some(left: JsArray) =>
+          m2.get(key) match {
+            case Some(right: JsArray) =>
+              JsArray(for ( (l, r) <- left.elements zip right.elements )
+                yield JsonMerge(l, r))
+            case _ => left
+          }
+        case Some(j: JsValue) =>
+          j
+        case None =>
+          m2(key)
+      }
+      key -> value
+    }
+  }.toMap
+
+  /** Merge two Json trees, recursion through object, preferring values on lefts side in conflict. */
+  def apply(o1: JsValue, o2: JsValue): JsValue = {
+    Try{
+      JsObject(mergeMaps(o1.asJsObject.fields, o2.asJsObject.fields))
+    }.getOrElse(o1)
+  }
+}

--- a/src/main/scala/com/azavea/modellab/Service.scala
+++ b/src/main/scala/com/azavea/modellab/Service.scala
@@ -37,8 +37,9 @@ object Service extends SimpleRoutingApp with DataHubCatalog with Instrumented wi
       requestInstance { req =>
         respondWithHeader(RawHeader("Access-Control-Allow-Origin", "*")) {
           complete {
-            val json = req.entity.asString.parseJson      
-            registry.register(json)
+            val requestJson = req.entity.asString.parseJson
+            val renderedJson = registry.register(requestJson)
+            JsonMerge(renderedJson, requestJson).asJsObject
           }
         }
       } 


### PR DESCRIPTION
POST to `/layers` of:
```json
{
  "name": "FocalSlope",
  "ui": "beautiful",
  "neighborhood": {
    "shape": "square",
    "size": 1,
    "color": "blue?"
  },
  "z_factor": 1,
  "inputs": [
    {
      "name": "LoadLayer",
      "layer_name": "us-pennsylvania-philadelphia-elevation-30m-epsg3857",
      "method": "faaaaast"
    }
  ]
}
```

will produce:

```json
{
  "name": "FocalSlope",
  "neighborhood": {
    "size": 1,
    "shape": "square",
    "color": "blue?"
  },
  "hash": "URDNIIA",
  "inputs": [{
    "method": "faaaaast",
    "name": "LoadLayer",
    "layer_name": "us-pennsylvania-philadelphia-elevation-30m-epsg3857",
    "hash": "GVWWZ5Y",
    "inputs": []
  }],
  "ui": "beautiful",
  "z_factor": 1.0
}
```
Note this behavior does not actually store the extra fields on the service, just rolls them over per registration request. Therefore GET to `/layers/<hash>` will not have extra fields. Is that kind of behavior acceptable?