### PR TITLE
Remove Librato token

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,3 +1,3 @@
-librato.username = "echeipesh@gmail.com"
-librato.token = "60d8dd9074d0e554a643334a23800b0bfae6ebcd210377e7f6dfa99f29dc8b41"
-librato.source = "bear"
+# librato.username = 
+# librato.token = 
+# librato.source = 


### PR DESCRIPTION
this disables Librato metrics module. Can be re-enabled by providing `application.conf` alongside the assembly jar.
